### PR TITLE
Added build support for MacOSX

### DIFF
--- a/wrappers/java/README.md
+++ b/wrappers/java/README.md
@@ -17,6 +17,12 @@ gradle publishToMavenLocal
 ```
 Builds with JDK 8, seems to fail with JDK 9.
 
+Under OSX, the native libraries of realsense are not bundled with the jar. You have to copy all the library files (and soft links) into the following directory:
+
+```
+/librealsense/wrappers/java/src/main/resources/lib/org.librealsense/osx-x64
+```
+
 ## Using pre-built binaries
 
 Currently Windows only! Ready to go jar files are hosted on bintray.

--- a/wrappers/java/README.md
+++ b/wrappers/java/README.md
@@ -1,18 +1,26 @@
 # Java wrapper for librealsense
 
-Work in progress, currently targeting Windows 10. At this point it works well enough to receive depth streams from multiple sensors, but all other use is currently highly untested.
+Work in progress, currently targeting Windows 10 and Mac OSX. At this point it works well enough to receive depth streams from multiple sensors, but all other use is currently highly untested.
 
 ## Building
 
+First you have to build librealsense itself on your platform.
+
 ```sh
+# windows
 ./gradlew build
 ./gradlew publishToMavenLocal
+
+# osx / unix
+gradle build
+gradle publishToMavenLocal
 ```
 Builds with JDK 8, seems to fail with JDK 9.
 
 ## Using pre-built binaries
 
-Currently Windows only! Ready to go jar files are hosted on bintray. 
+Currently Windows only! Ready to go jar files are hosted on bintray.
+
 ```groovy
 repositories {
     maven {

--- a/wrappers/java/build.gradle
+++ b/wrappers/java/build.gradle
@@ -60,7 +60,11 @@ model {
                 lib new JNIDependency(project)
                 cppCompiler.args "-I${project.projectDir}/../../include"
                 linker.args "-L${project.projectDir}/../../"
-                linker.args "-lrealsense2"
+
+                if (targetPlatform.operatingSystem.macOsX) {
+                    cppCompiler.args "-I${project.projectDir}/../../include"
+                    linker.args "${project.projectDir}/../../build/Debug/librealsense2.dylib"
+                }
 
                 if (targetPlatform.operatingSystem.windows) {
 
@@ -78,6 +82,7 @@ model {
 
 //                    linker.args "/LIBPATH:C:/Program Files (x86)/Windows Kits/10/Lib/10.0.10586.0/ucrt/${arch}"
                     cppCompiler.args "-I${project.projectDir}/../../include"
+                    linker.args "-lrealsense2"
                     linker.args "/LIBPATH:${project.projectDir}/../../Debug/"
                     linker.args "realsense2.lib"
 
@@ -111,5 +116,3 @@ model {
         }
     }
 }
-
-

--- a/wrappers/java/build.gradle
+++ b/wrappers/java/build.gradle
@@ -30,8 +30,6 @@ placeholder.deleteOnExit()
 apply plugin: 'maven-publish'
 
 model {
-
-
     platforms {
         ['windows', 'linux', 'osx', 'freebsd-10', 'solaris'].each { os ->
             ['x64'].each { arch ->
@@ -85,7 +83,6 @@ model {
                     linker.args "-lrealsense2"
                     linker.args "/LIBPATH:${project.projectDir}/../../Debug/"
                     linker.args "realsense2.lib"
-
                 }
             }
         }

--- a/wrappers/java/src/main/java/org.librealsense/Native.java
+++ b/wrappers/java/src/main/java/org.librealsense/Native.java
@@ -22,7 +22,7 @@ public class Native {
         } else if (os.contains("nix") || os.contains("nux") || os.contains("aix")) {
             // TODO: implement unix support
         } else {
-            throw Exception("Operating System not supported!");
+            // Operating System not supported!
         }
     }
 

--- a/wrappers/java/src/main/java/org.librealsense/Native.java
+++ b/wrappers/java/src/main/java/org.librealsense/Native.java
@@ -18,6 +18,7 @@ public class Native {
             loadLibrary("/lib/org.librealsense/windows-x64/realsense2.dll", "realsense2.dll");
             loadLibrary("/lib/org.librealsense/windows-x64/native.dll", "native.dll");
         } else if (os.contains("mac")) {
+            loadLibrary("/lib/org.librealsense/osx-x64/librealsense2.dylib", "librealsense2.dylib");
             loadLibrary("/lib/org.librealsense/osx-x64/libnative.dylib", "libnative.dylib");
         } else if (os.contains("nix") || os.contains("nux") || os.contains("aix")) {
             // TODO: implement unix support

--- a/wrappers/java/src/main/java/org.librealsense/Native.java
+++ b/wrappers/java/src/main/java/org.librealsense/Native.java
@@ -7,13 +7,23 @@ import java.io.OutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+
 public class Native {
 
     static {
+        // load native os specific libraries
+        String os = System.getProperty("os.name").toLowerCase();
 
-        loadLibrary("/lib/org.librealsense/windows-x64/realsense2.dll", "realsense2.dll");
-        loadLibrary("/lib/org.librealsense/windows-x64/native.dll", "native.dll");
-
+        if (os.contains("win")) {
+            loadLibrary("/lib/org.librealsense/windows-x64/realsense2.dll", "realsense2.dll");
+            loadLibrary("/lib/org.librealsense/windows-x64/native.dll", "native.dll");
+        } else if (os.contains("mac")) {
+            loadLibrary("/lib/org.librealsense/osx-x64/libnative.dylib", "libnative.dylib");
+        } else if (os.contains("nix") || os.contains("nux") || os.contains("aix")) {
+            // TODO: implement unix support
+        } else {
+            throw Exception("Operating System not supported!");
+        }
     }
 
     static void loadLibrary(String resource, String target) {
@@ -30,7 +40,7 @@ public class Native {
                 OutputStream out = new FileOutputStream(jinectLib);
                 byte[] buffer = new byte[1024];
                 int len;
-                while (( len = stream.read(buffer)) != -1) {
+                while ((len = stream.read(buffer)) != -1) {
                     out.write(buffer, 0, len);
                 }
                 out.close();
@@ -126,48 +136,132 @@ public class Native {
     }
 
     public static enum Option {
-        RS2_OPTION_BACKLIGHT_COMPENSATION                     , /**< Enable / disable color backlight compensation*/
-        RS2_OPTION_BRIGHTNESS                                 , /**< Color image brightness*/
-        RS2_OPTION_CONTRAST                                   , /**< Color image contrast*/
-        RS2_OPTION_EXPOSURE                                   , /**< Controls exposure time of color camera. Setting any value will disable auto exposure*/
-        RS2_OPTION_GAIN                                       , /**< Color image gain*/
-        RS2_OPTION_GAMMA                                      , /**< Color image gamma setting*/
-        RS2_OPTION_HUE                                        , /**< Color image hue*/
-        RS2_OPTION_SATURATION                                 , /**< Color image saturation setting*/
-        RS2_OPTION_SHARPNESS                                  , /**< Color image sharpness setting*/
-        RS2_OPTION_WHITE_BALANCE                              , /**< Controls white balance of color image. Setting any value will disable auto white balance*/
-        RS2_OPTION_ENABLE_AUTO_EXPOSURE                       , /**< Enable / disable color image auto-exposure*/
-        RS2_OPTION_ENABLE_AUTO_WHITE_BALANCE                  , /**< Enable / disable color image auto-white-balance*/
-        RS2_OPTION_VISUAL_PRESET                              , /**< Provide access to several recommend sets of option presets for the depth camera */
-        RS2_OPTION_LASER_POWER                                , /**< Power of the F200 / SR300 projector, with 0 meaning projector off*/
-        RS2_OPTION_ACCURACY                                   , /**< Set the number of patterns projected per frame. The higher the accuracy value the more patterns projected. Increasing the number of patterns help to achieve better accuracy. Note that this control is affecting the Depth FPS */
-        RS2_OPTION_MOTION_RANGE                               , /**< Motion vs. Range trade-off, with lower values allowing for better motion sensitivity and higher values allowing for better depth range*/
-        RS2_OPTION_FILTER_OPTION                              , /**< Set the filter to apply to each depth frame. Each one of the filter is optimized per the application requirements*/
-        RS2_OPTION_CONFIDENCE_THRESHOLD                       , /**< The confidence level threshold used by the Depth algorithm pipe to set whether a pixel will get a valid range or will be marked with invalid range*/
-        RS2_OPTION_EMITTER_ENABLED                            , /**< Laser Emitter enabled */
-        RS2_OPTION_FRAMES_QUEUE_SIZE                          , /**< Number of frames the user is allowed to keep per stream. Trying to hold-on to more frames will cause frame-drops.*/
-        RS2_OPTION_TOTAL_FRAME_DROPS                          , /**< Total number of detected frame drops from all streams */
-        RS2_OPTION_AUTO_EXPOSURE_MODE                         , /**< Auto-Exposure modes: Static, Anti-Flicker and Hybrid */
-        RS2_OPTION_POWER_LINE_FREQUENCY                       , /**< Power Line Frequency control for anti-flickering Off/50Hz/60Hz/Auto */
-        RS2_OPTION_ASIC_TEMPERATURE                           , /**< Current Asic Temperature */
-        RS2_OPTION_ERROR_POLLING_ENABLED                      , /**< disable error handling */
-        RS2_OPTION_PROJECTOR_TEMPERATURE                      , /**< Current Projector Temperature */
-        RS2_OPTION_OUTPUT_TRIGGER_ENABLED                     , /**< Enable / disable trigger to be outputed from the camera to any external device on every depth frame */
-        RS2_OPTION_MOTION_MODULE_TEMPERATURE                  , /**< Current Motion-Module Temperature */
-        RS2_OPTION_DEPTH_UNITS                                , /**< Number of meters represented by a single depth unit */
-        RS2_OPTION_ENABLE_MOTION_CORRECTION                   , /**< Enable/Disable automatic correction of the motion data */
-        RS2_OPTION_AUTO_EXPOSURE_PRIORITY                     , /**< Allows sensor to dynamically ajust the frame rate depending on lighting conditions */
-        RS2_OPTION_COLOR_SCHEME                               , /**< Color scheme for data visualization */
-        RS2_OPTION_HISTOGRAM_EQUALIZATION_ENABLED             , /**< Perform histogram equalization post-processing on the depth data */
-        RS2_OPTION_MIN_DISTANCE                               , /**< Minimal distance to the target */
-        RS2_OPTION_MAX_DISTANCE                               , /**< Maximum distance to the target */
-        RS2_OPTION_TEXTURE_SOURCE                             , /**< Texture mapping stream unique ID */
-        RS2_OPTION_FILTER_MAGNITUDE                           , /**< The 2D-filter effect. The specific interpretation is given within the context of the filter */
-        RS2_OPTION_FILTER_SMOOTH_ALPHA                        , /**< 2D-filter parameter controls the weight/radius for smoothing.*/
-        RS2_OPTION_FILTER_SMOOTH_DELTA                        , /**< 2D-filter range/validity threshold*/
-        RS2_OPTION_HOLES_FILL                                 , /**< Enhance depth data post-processing with holes filling where appropriate*/
-        RS2_OPTION_STEREO_BASELINE                            , /**< The distance in mm between the first and the second imagers in stereo-based depth cameras*/
-        RS2_OPTION_AUTO_EXPOSURE_CONVERGE_STEP                , /**< Allows dynamically ajust the converge step value of the target exposure in Auto-Exposure algorithm*/
+        RS2_OPTION_BACKLIGHT_COMPENSATION, /**
+         * < Enable / disable color backlight compensation
+         */
+        RS2_OPTION_BRIGHTNESS, /**
+         * < Color image brightness
+         */
+        RS2_OPTION_CONTRAST, /**
+         * < Color image contrast
+         */
+        RS2_OPTION_EXPOSURE, /**
+         * < Controls exposure time of color camera. Setting any value will disable auto exposure
+         */
+        RS2_OPTION_GAIN, /**
+         * < Color image gain
+         */
+        RS2_OPTION_GAMMA, /**
+         * < Color image gamma setting
+         */
+        RS2_OPTION_HUE, /**
+         * < Color image hue
+         */
+        RS2_OPTION_SATURATION, /**
+         * < Color image saturation setting
+         */
+        RS2_OPTION_SHARPNESS, /**
+         * < Color image sharpness setting
+         */
+        RS2_OPTION_WHITE_BALANCE, /**
+         * < Controls white balance of color image. Setting any value will disable auto white balance
+         */
+        RS2_OPTION_ENABLE_AUTO_EXPOSURE, /**
+         * < Enable / disable color image auto-exposure
+         */
+        RS2_OPTION_ENABLE_AUTO_WHITE_BALANCE, /**
+         * < Enable / disable color image auto-white-balance
+         */
+        RS2_OPTION_VISUAL_PRESET, /**
+         * < Provide access to several recommend sets of option presets for the depth camera
+         */
+        RS2_OPTION_LASER_POWER, /**
+         * < Power of the F200 / SR300 projector, with 0 meaning projector off
+         */
+        RS2_OPTION_ACCURACY, /**
+         * < Set the number of patterns projected per frame. The higher the accuracy value the more patterns projected. Increasing the number of patterns help to achieve better accuracy. Note that this control is affecting the Depth FPS
+         */
+        RS2_OPTION_MOTION_RANGE, /**
+         * < Motion vs. Range trade-off, with lower values allowing for better motion sensitivity and higher values allowing for better depth range
+         */
+        RS2_OPTION_FILTER_OPTION, /**
+         * < Set the filter to apply to each depth frame. Each one of the filter is optimized per the application requirements
+         */
+        RS2_OPTION_CONFIDENCE_THRESHOLD, /**
+         * < The confidence level threshold used by the Depth algorithm pipe to set whether a pixel will get a valid range or will be marked with invalid range
+         */
+        RS2_OPTION_EMITTER_ENABLED, /**
+         * < Laser Emitter enabled
+         */
+        RS2_OPTION_FRAMES_QUEUE_SIZE, /**
+         * < Number of frames the user is allowed to keep per stream. Trying to hold-on to more frames will cause frame-drops.
+         */
+        RS2_OPTION_TOTAL_FRAME_DROPS, /**
+         * < Total number of detected frame drops from all streams
+         */
+        RS2_OPTION_AUTO_EXPOSURE_MODE, /**
+         * < Auto-Exposure modes: Static, Anti-Flicker and Hybrid
+         */
+        RS2_OPTION_POWER_LINE_FREQUENCY, /**
+         * < Power Line Frequency control for anti-flickering Off/50Hz/60Hz/Auto
+         */
+        RS2_OPTION_ASIC_TEMPERATURE, /**
+         * < Current Asic Temperature
+         */
+        RS2_OPTION_ERROR_POLLING_ENABLED, /**
+         * < disable error handling
+         */
+        RS2_OPTION_PROJECTOR_TEMPERATURE, /**
+         * < Current Projector Temperature
+         */
+        RS2_OPTION_OUTPUT_TRIGGER_ENABLED, /**
+         * < Enable / disable trigger to be outputed from the camera to any external device on every depth frame
+         */
+        RS2_OPTION_MOTION_MODULE_TEMPERATURE, /**
+         * < Current Motion-Module Temperature
+         */
+        RS2_OPTION_DEPTH_UNITS, /**
+         * < Number of meters represented by a single depth unit
+         */
+        RS2_OPTION_ENABLE_MOTION_CORRECTION, /**
+         * < Enable/Disable automatic correction of the motion data
+         */
+        RS2_OPTION_AUTO_EXPOSURE_PRIORITY, /**
+         * < Allows sensor to dynamically ajust the frame rate depending on lighting conditions
+         */
+        RS2_OPTION_COLOR_SCHEME, /**
+         * < Color scheme for data visualization
+         */
+        RS2_OPTION_HISTOGRAM_EQUALIZATION_ENABLED, /**
+         * < Perform histogram equalization post-processing on the depth data
+         */
+        RS2_OPTION_MIN_DISTANCE, /**
+         * < Minimal distance to the target
+         */
+        RS2_OPTION_MAX_DISTANCE, /**
+         * < Maximum distance to the target
+         */
+        RS2_OPTION_TEXTURE_SOURCE, /**
+         * < Texture mapping stream unique ID
+         */
+        RS2_OPTION_FILTER_MAGNITUDE, /**
+         * < The 2D-filter effect. The specific interpretation is given within the context of the filter
+         */
+        RS2_OPTION_FILTER_SMOOTH_ALPHA, /**
+         * < 2D-filter parameter controls the weight/radius for smoothing.
+         */
+        RS2_OPTION_FILTER_SMOOTH_DELTA, /**
+         * < 2D-filter range/validity threshold
+         */
+        RS2_OPTION_HOLES_FILL, /**
+         * < Enhance depth data post-processing with holes filling where appropriate
+         */
+        RS2_OPTION_STEREO_BASELINE, /**
+         * < The distance in mm between the first and the second imagers in stereo-based depth cameras
+         */
+        RS2_OPTION_AUTO_EXPOSURE_CONVERGE_STEP, /**
+         * < Allows dynamically ajust the converge step value of the target exposure in Auto-Exposure algorithm
+         */
         RS2_OPTION_COUNT                                        /**< Number of enumeration values. Not a valid input: intended to be used in for-loops. */
 
     }
@@ -188,49 +282,77 @@ public class Native {
     public native static long rs2CreatePipeline(long context);
 
     public native static long rs2CreateConfig();
+
     public native static void rs2DeleteConfig(long config);
 
 
     public native static void rs2ConfigEnableStream(long config, int stream, int index, int width, int height, int format, int framerate);
+
     public native static void rs2ConfigEnableDevice(long config, String serial);
+
     public native static void rs2ConfigDisableStream(long config, long stream);
+
     public native static int rs2ConfigCanResolve(long config, long pipeline);
 
     public native static long rs2PipelineStartWithConfig(long pipeline, long config);
+
     public native static long rs2PipelineProfileGetStreams(long pipelineProfile);
 
     public native static long rs2PipelineWaitForFrames(long pipeline, int timeOut);
+
     public native static int rs2EmbeddedFramesCount(long frames);
+
     public native static long rs2ExtractFrame(long frames, int index);
+
     public native static long rs2ReleaseFrame(long frame);
+
     public native static int rs2IsFrameExtendableTo(long frame, int extension);
+
     public native static int rs2GetFrameWidth(long frame);
+
     public native static int rs2GetFrameHeight(long frame);
+
     public native static int rs2GetFrameStrideInBytes(long frame);
+
     public native static float rs2DepthFrameGetDistance(long frame, int x, int y);
+
     public native static ByteBuffer rs2GetFrameData(long frame);
 
 
     public native static long rs2QuerySensors(long device);
+
     public native static int rs2GetSensorsCount(long sensorList);
+
     public native static void rs2DeleteSensorList(long sensorList);
+
     public native static void rs2DeleteSensor(long sensor);
+
     public native static long rs2CreateSensor(long sensorList, int index);
+
     public native static String rs2GetSensorInfo(long sensor, int cameraInfo);
+
     public native static int rs2SupportsSensorInfo(long sensor, int cameraInfo);
+
     public native static int rs2IsSensorExtendableTo(long sensor, int extension);
+
     public native static float rs2GetDepthScale(long sensor);
+
     public native static float rs2DepthStereoFrameGetBaseline(long frame);
+
     public native static long rs2GetStreamProfiles(long sensor);
+
     public native static int rs2GetStreamProfileCount(long streamProfileList);
+
     public native static void rs2DeleteStreamProfilesList(long streamProfileList);
 
 
     public native static long rs2GetStreamProfile(long streamProfileList, int index);
-    public native static void rs2DeleteStreamProfile(long streamProfile);
-    public native static long rs2GetVideoStreamIntrinsics(long streamProfile, Intrinsics intrinsics);
-    public native static long rs2DeleteIntrinsics(long intrinsics);
 
+    public native static void rs2DeleteStreamProfile(long streamProfile);
+
+    public native static long rs2GetVideoStreamIntrinsics(long streamProfile, Intrinsics intrinsics);
+
+    public native static long rs2DeleteIntrinsics(long intrinsics);
 
 
     public static void main(String[] args) {
@@ -270,9 +392,8 @@ public class Native {
 
         long pipeline = rs2CreatePipeline(context);
         long config = rs2CreateConfig();
-        rs2ConfigEnableStream(config, Stream.RS2_STREAM_DEPTH.ordinal(), 0,640, 480, Format.RS2_FORMAT_Z16.ordinal(), 30);
+        rs2ConfigEnableStream(config, Stream.RS2_STREAM_DEPTH.ordinal(), 0, 640, 480, Format.RS2_FORMAT_Z16.ordinal(), 30);
         rs2PipelineStartWithConfig(pipeline, config);
-
 
 
         while (true) {


### PR DESCRIPTION
These changes add the build support for MacOSX and the support to add multi os libraries to the jar.
Currently bundling of the native realsense libs is not support in the gradle build. The `dylib` files have to be copied by hand into the resource folder of the java wrapper (as written in the readme).